### PR TITLE
test assumption for remove volume

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -62,6 +62,8 @@ var _ = Describe("Certify with: ", func() {
 			delete(config.CreateConfig.Opts, "password")
 
 			errResponse = driverClient.Create(testEnv, config.CreateConfig)
+			// Unmount already handles the volume deletion. Remove always succeeds whether volume exists or not (idempotent).
+			// This is an extra safety check to ensure proper cleanup.
 			Expect(errResponse.Err).To(Equal(""))
 
 		})
@@ -75,7 +77,7 @@ var _ = Describe("Certify with: ", func() {
 			errResponse = driverClient.Remove(testEnv, dockerdriver.RemoveRequest{
 				Name: config.CreateConfig.Name,
 			})
-			Expect(errResponse.Err).To(ContainSubstring(fmt.Sprintf("Volume %s does not exist", config.CreateConfig.Name)))
+			Expect(errResponse.Err).To(Equal(""))
 		})
 
 		It("should log an error message", func() {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
With new go.mod update, umount cleans the volume regardless of the failure. So the error is not propagated to remove volume and returns empty.

https://github.com/cloudfoundry/smb-volume-release/blob/c534ae0c7a174c6a053da1a8540a6087ceb036fd/src/code.cloudfoundry.org/smbbroker/vendor/code.cloudfoundry.org/volumedriver/volume_driver.go#L289

```
             [FAILED] Expected  
                 <string>:   
             to contain substring  
                 <string>: Volume 670823c3-b7f4-4499-9894-f3aea6aea012-1 does not exist  
             In [AfterEach] at: /var/vcap/packages/dockerdriver-integration/src/code.cloudfoundry.org/dockerdriver/integration/integration_test.go:78 @ 01/30/26 23:15:49.093  
           ------------------------------  
           ••••  
             
           Summarizing 1 Failure:  
             [FAIL] Certify with:  given a created volume missing required options [AfterEach] should log an error message  
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
